### PR TITLE
Restore user relation for earnings and secure profit claiming

### DIFF
--- a/core/migrations/0029_userearnings_user.py
+++ b/core/migrations/0029_userearnings_user.py
@@ -1,0 +1,44 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+def assign_users_to_earnings(apps, schema_editor):
+    User = apps.get_model(settings.AUTH_USER_MODEL)
+    UserEarnings = apps.get_model('core', 'UserEarnings')
+
+    default_user = User.objects.order_by('id').first()
+    if default_user is None:
+        return
+
+    available_users = list(User.objects.filter(earnings__isnull=True).order_by('id'))
+    user_iterator = iter(available_users)
+
+    for earnings in UserEarnings.objects.filter(user__isnull=True).order_by('id'):
+        try:
+            user = next(user_iterator)
+        except StopIteration:
+            user = default_user
+        earnings.user = user
+        earnings.save(update_fields=['user'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0028_walletuser'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userearnings',
+            name='user',
+            field=models.OneToOneField(null=True, on_delete=models.CASCADE, related_name='earnings', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.RunPython(assign_users_to_earnings, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name='userearnings',
+            name='user',
+            field=models.OneToOneField(on_delete=models.CASCADE, related_name='earnings', to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -264,7 +264,7 @@ class ChatMessage(models.Model):
 
 
 class UserEarnings(models.Model):
-    # user = models.OneToOneField(User, on_delete=models.CASCADE)
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='earnings')
     profit_per_hour = models.IntegerField(default=100) 
     last_claimed = models.DateTimeField(default=timezone.now)
     total_collected = models.IntegerField(default=0)

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,51 @@
-from django.test import TestCase
+from datetime import timedelta
 
-# Create your tests here.
+from django.contrib.auth.models import User
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from . import models
+
+
+class ClaimProfitViewTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="password123")
+        self.earnings = models.UserEarnings.objects.create(
+            user=self.user,
+            profit_per_hour=100,
+            last_claimed=timezone.now() - timedelta(hours=2),
+            total_collected=50,
+        )
+
+    def test_get_pending_profit_for_authenticated_user(self):
+        expected_pending = self.earnings.calculate_pending_profit()
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(reverse("profit"))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get("pending_profit"), expected_pending)
+
+    def test_claim_profit_updates_totals(self):
+        expected_pending = self.earnings.calculate_pending_profit()
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(reverse("profit"))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        claimed = response.data.get("claimed")
+        self.assertEqual(claimed, expected_pending)
+
+        self.earnings.refresh_from_db()
+        self.assertEqual(self.earnings.total_collected, 50 + expected_pending)
+
+    def test_earnings_created_for_user_without_record(self):
+        other_user = User.objects.create_user(username="newuser", password="password123")
+        self.client.force_authenticate(user=other_user)
+
+        response = self.client.get(reverse("profit"))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(models.UserEarnings.objects.filter(user=other_user).exists())

--- a/core/views.py
+++ b/core/views.py
@@ -273,15 +273,22 @@ class SettingsAPIView(APIView):
 
 
 class ClaimProfitView(APIView):
-    # permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated]
+
+    def _get_user_earnings(self, user):
+        earnings, _ = models.UserEarnings.objects.get_or_create(
+            user=user,
+            defaults={"last_claimed": timezone.now()},
+        )
+        return earnings
 
     def get(self, request):
-        earnings = models.UserEarnings.objects.get(id=1)
+        earnings = self._get_user_earnings(request.user)
         pending = earnings.calculate_pending_profit()
         return Response({"pending_profit": pending})
 
     def post(self, request):
-        earnings = models.UserEarnings.objects.get(user=1)
+        earnings = self._get_user_earnings(request.user)
         claimed = earnings.claim_profit()
         return Response({"claimed": claimed, "total_collected": earnings.total_collected})
     


### PR DESCRIPTION
## Summary
- restore the one-to-one link between `UserEarnings` and the auth user with a data migration to backfill existing rows
- update `ClaimProfitView` to require authentication and operate on the requesting user's earnings record, creating it on demand
- add API tests that exercise pending-profit retrieval, claiming, and automatic earnings creation

## Testing
- python manage.py test core

------
https://chatgpt.com/codex/tasks/task_e_68d137689b78832399aacaa89cfec2d2